### PR TITLE
Fix DN when creating a machine account

### DIFF
--- a/Sharpmad/MAQ.cs
+++ b/Sharpmad/MAQ.cs
@@ -96,7 +96,7 @@ namespace Sharpmad
             }
             else if (!String.IsNullOrEmpty(node))
             {
-                distinguishedName = String.Concat("DC=", node, ",", distinguishedName);
+                distinguishedName = String.Concat("CN=", node, ",", distinguishedName);
             }
 
             return distinguishedName;


### PR DESCRIPTION
Fix distinguished name when creating a machine account within a non-default container.