### PR TITLE
Enable ADIDNS REMOVE functionality

### DIFF
--- a/Sharpmad/Program.cs
+++ b/Sharpmad/Program.cs
@@ -431,6 +431,10 @@ namespace Sharpmad
                             ADIDNS.RenameADIDNSNode(argDistinguishedName, argDomain, argDomainController, argNode, argNodeNew, argPartition, argZone, argVerbose, credential);
                             break;
 
+                        case "REMOVE":
+                            ADIDNS.RemoveADIDNSNode(argDistinguishedName, argDomain, argDomainController, argAttribute, argNode, argNodeNew, argPartition, argZone, argVerbose, credential);
+                            break;
+
                         case "REMOVEACE":
                             ADIDNS.RemoveADIDNSACE(argDistinguishedName, argDomain, argDomainController, argNode, argPartition, argPrincipal, argAccessType, argZone, argAccess, argVerbose, credential);
                             break;


### PR DESCRIPTION
Enables the already existing feature that allows DNS entries to be removed